### PR TITLE
Fix bug caused by pulling down very fast

### DIFF
--- a/TB_TwitterHeader/ViewController.swift
+++ b/TB_TwitterHeader/ViewController.swift
@@ -93,19 +93,19 @@ class ViewController: UIViewController, UIScrollViewDelegate {
             avatarTransform = CATransform3DTranslate(avatarTransform, 0, avatarSizeVariation, 0)
             avatarTransform = CATransform3DScale(avatarTransform, 1.0 - avatarScaleFactor, 1.0 - avatarScaleFactor, 0)
             
-            if offset <= offset_HeaderStop {
-                
-                if avatarImage.layer.zPosition < header.layer.zPosition{
-                    header.layer.zPosition = 0
-                }
-                
-            }else {
-                if avatarImage.layer.zPosition >= header.layer.zPosition{
-                    header.layer.zPosition = 2
-                }
-            }
         }
         
+        if offset <= offset_HeaderStop {
+            
+            if avatarImage.layer.zPosition < header.layer.zPosition{
+                header.layer.zPosition = 0
+            }
+            
+        }else {
+            if avatarImage.layer.zPosition >= header.layer.zPosition{
+                header.layer.zPosition = 2
+            }
+        }
         // Apply Transformations
         
         header.layer.transform = headerTransform


### PR DESCRIPTION
Hey ariok！
I found that avatar can’t appear above headerView on time  When pulling down very fast . 
Because the offset is negative.
